### PR TITLE
Add Input Params to Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A GitHub Action to run [HAML-Lint](https://github.com/sds/haml-lint) against you
   - [:page_facing_up: Introduction](#pagefacingup-introduction)
   - [:bulb: Usage](#bulb-usage)
     - [:package: Example Workflow](#package-example-workflow)
+    - [:moneybag: Available Inputs](#moneybag-available-inputs)
   - [:warning: Gotchas](#warning-gotchas)
   - [:camera_flash: Screenshots](#cameraflash-screenshots)
   - [:bookmark: Changelog](#bookmark-changelog)
@@ -38,6 +39,9 @@ Add the following to your GitHub action workflow to use HAML Lint Action:
 ```yaml
 - name: HAML Lint
   uses: andrewmcodes/haml-lint-action@v0.0.1
+  with:
+    file_paths: 'app/**/*.html.haml'
+    fail_level: 'error'
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -58,9 +62,23 @@ jobs:
     - uses: actions/checkout@v1
     - name: HAML Lint
       uses: andrewmcodes/haml-lint-action@v0.0.1
+      with:
+        file_paths: 'app/**/*.html.haml'
+        fail_level: 'error'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+### :moneybag: Available Inputs
+
+| Input Parm Name | Required | Default Value        | Description                                                                                         |
+| ---             | ---      | ---                  | ---                                                                                                 |
+| file_paths      | false    | 'app/**/*.html.haml' | Define the paths you wish to be linted per run. multiple paths can be on one line just add a space. |
+| version         | false    | latest GA            | Define a later version of haml_lint if latest is not needed                                         |
+| additional_gems | false    |                      | Additional Gems can be installed via one line with spaces and commands are supported like a version |
+| config_path     | false    | repo ./              | If the config path is another spot in the repo or not named .haml-lint.yml                          |
+| exclude_paths   | false    |                      | Define a list of paths to exclude from being linted.                                                |
+| fail_level      | false    | 'error'              | Can define 'error' or 'warning' to cause haml-lint to error out on                                  |
 
 ## :warning: Gotchas
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ jobs:
 
 | Input Parm Name | Required | Default Value        | Description                                                                                         |
 | ---             | ---      | ---                  | ---                                                                                                 |
+| bundle          | false    | false                | If you want to use a version of a gem you maintain this is your best bet, longer time for load could be seen |
 | file_paths      | false    | 'app/**/*.html.haml' | Define the paths you wish to be linted per run. multiple paths can be on one line just add a space. |
 | version         | false    | latest GA            | Define a later version of haml_lint if latest is not needed                                         |
 | additional_gems | false    |                      | Additional Gems can be installed via one line with spaces and commands are supported like a version |

--- a/action.yml
+++ b/action.yml
@@ -2,9 +2,16 @@
 name: 'HAML Lint Action'
 description: 'A GitHub Action that lints your HAML code with HAML Lint!'
 author: 'Andrew Mason <andrewmcodes@protonmail.com>'
+inputs:
+  additional_gems:
+    description: 'Add Additional Gems to install during setup'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'
+  args:
+    - ${{ inputs.additional_gems }}
 env:
   GITHUB_TOKEN: secrets.GITHUB_TOKEN
 branding:

--- a/action.yml
+++ b/action.yml
@@ -33,10 +33,10 @@ runs:
     - ${{ inputs.additional_gems }}
 env:
   GITHUB_TOKEN: secrets.GITHUB_TOKEN
-  FILE_PATHS: ${{ inputs.file_paths }}
-  CONFIG_PATH: ${{ inputs.config_path }}
-  EXCLUDE_FILES: ${{ inputs.exclude_paths }}
-  FAIL_LEVEL: ${{ inputs.fail_level }}
+  FILE_PATHS: inputs.file_paths
+  CONFIG_PATH: inputs.config_path
+  EXCLUDE_FILES: inputs.exclude_paths
+  FAIL_LEVEL: inputs.fail_level
 branding:
   icon: 'code'
   color: 'orange'

--- a/action.yml
+++ b/action.yml
@@ -3,17 +3,40 @@ name: 'HAML Lint Action'
 description: 'A GitHub Action that lints your HAML code with HAML Lint!'
 author: 'Andrew Mason <andrewmcodes@protonmail.com>'
 inputs:
+  version:
+    description: 'Define spcific Haml Lint gem version to use'
+    required: false
+    default: ''
   additional_gems:
     description: 'Add Additional Gems to install during setup'
     required: false
     default: ''
+  file_paths:
+    description: 'File paths for Haml Lint to analyze typically app/views/**/*'
+    required: false
+    default: 'app/**/*.html.haml'
+  config_path:
+    description: 'Path to Haml config file not in the base repo path ./'
+    required: false
+  exclude_paths:
+    description: 'Haml lint command Exclude one or more files from being linted'
+    required: false
+  fail_level:
+    description: 'Specify the minimum severity (warning or error) for which the lint should fail'
+    required: false
+    default: 'error'
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
+    - ${{ inputs.version }}
     - ${{ inputs.additional_gems }}
 env:
   GITHUB_TOKEN: secrets.GITHUB_TOKEN
+  FILE_PATHS: ${{ inputs.file_paths }}
+  CONFIG_PATH: ${{ inputs.config_path }}
+  EXCLUDE_FILES: ${{ inputs.exclude_paths }}
+  FAIL_LEVEL: ${{ inputs.fail_level }}
 branding:
   icon: 'code'
   color: 'orange'

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: 'Specify the minimum severity (warning or error) for which the lint should fail'
     required: false
     default: 'error'
+  bundle:
+    description: 'Useful gemfile, useful for using your oen version of the gem'
+    required: false
+    default: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,7 @@ runs:
   args:
     - ${{ inputs.version }}
     - ${{ inputs.additional_gems }}
+    - ${{ inputs.bundle }}
 env:
   GITHUB_TOKEN: secrets.GITHUB_TOKEN
 branding:

--- a/action.yml
+++ b/action.yml
@@ -33,10 +33,6 @@ runs:
     - ${{ inputs.additional_gems }}
 env:
   GITHUB_TOKEN: secrets.GITHUB_TOKEN
-  FILE_PATHS: inputs.file_paths
-  CONFIG_PATH: inputs.config_path
-  EXCLUDE_FILES: inputs.exclude_paths
-  FAIL_LEVEL: inputs.fail_level
 branding:
   icon: 'code'
   color: 'orange'

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-gem install haml-lint ${INPUT_ADDITIONAL_GEMS}
+gem install haml-lint "${INPUT_ADDITIONAL_GEMS}"
 
 ruby /action/lib/index.rb

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo "$1"
-gem install haml-lint "$1"
+echo "${1}"
+gem install haml-lint "${1}"
 
 ruby /action/lib/index.rb

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo "${1}"
-gem install haml-lint "${1}"
+echo "${INPUT_ADDITIONAL_GEMS}"
+gem install haml-lint "${INPUT_ADDITIONAL_GEMS}"
 
 ruby /action/lib/index.rb

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -2,7 +2,10 @@
 
 set -e
 
-if ["${INPUT_VERSION}" != ""]
+if ["${INPUT_BUNDLE}" == "true"]
+then
+  bundle install --jobs 4 --retry 3
+elif ["${INPUT_VERSION}" != ""]
 then
   gem install haml-lint ${INPUT_ADDITIONAL_GEMS}
 else

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -2,6 +2,7 @@
 
 set -e
 
-gem install haml-lint "${INPUT_ADDITIONAL_GEMS}"
+echo "$1"
+gem install haml-lint "$1"
 
 ruby /action/lib/index.rb

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-echo "${INPUT_ADDITIONAL_GEMS}"
 gem install haml-lint ${INPUT_ADDITIONAL_GEMS}
 
 ruby /action/lib/index.rb

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -2,6 +2,11 @@
 
 set -e
 
-gem install haml-lint ${INPUT_ADDITIONAL_GEMS}
+if ["${INPUT_VERSION}" != ""]
+then
+  gem install haml-lint ${INPUT_ADDITIONAL_GEMS}
+else
+  gem install haml-lint -v ${INPUT_VERSION} ${INPUT_ADDITIONAL_GEMS}
+fi
 
 ruby /action/lib/index.rb

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-gem install haml-lint
+gem install haml-lint ${INPUT_ADDITIONAL_GEMS}
 
 ruby /action/lib/index.rb

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -3,6 +3,6 @@
 set -e
 
 echo "${INPUT_ADDITIONAL_GEMS}"
-gem install haml-lint "${INPUT_ADDITIONAL_GEMS}"
+gem install haml-lint ${INPUT_ADDITIONAL_GEMS}
 
 ruby /action/lib/index.rb

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -18,11 +18,26 @@ end
   owner: ENV["GITHUB_REPOSITORY_OWNER"] || @event_json.dig("repository", "owner", "login"),
   repo: ENV["GITHUB_REPOSITORY_NAME"] || @event_json.dig("repository", "name"),
 }
+
+@params = {
+  file_paths: ENV["FILE_PATHS"],
+  config_path: ENV["CONFIG_PATH"],
+  exclude_files: ENV["EXCLUDE_FILES"],
+  fail_level: ENV["FAIL_LEVEL"]
+}
+
+@haml = "haml-lint -r json"
+@haml += " -c " + @params.config_path if ENV["CONFIG_PATH"]
+@haml += " -e " + @params.exclude_files if ENV["EXCLUDE_FILES"]
+@haml += " --fail-level " + @params.fail_level
+
 @report =
   if ENV["REPORT_PATH"]
     read_json(ENV["REPORT_PATH"])
   else
-    Dir.chdir(ENV["GITHUB_WORKSPACE"]) { JSON.parse(`haml-lint -r json`) }
+    Dir.chdir(ENV["GITHUB_WORKSPACE"]) {
+      JSON.parse(System(@haml))
+    }
   end
 
 GithubCheckRunService.new(@report, @github_data, ReportAdapter).run

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -30,7 +30,7 @@ end
     read_json(ENV["REPORT_PATH"])
   else
     Dir.chdir(ENV["GITHUB_WORKSPACE"]) {
-      JSON.parse(system(@haml))
+      JSON.parse(`#{@haml}`)
     }
   end
 

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -29,9 +29,7 @@ end
   if ENV["REPORT_PATH"]
     read_json(ENV["REPORT_PATH"])
   else
-    Dir.chdir(ENV["GITHUB_WORKSPACE"]) {
-      JSON.parse(`#{@haml}`)
-    }
+    Dir.chdir(ENV["GITHUB_WORKSPACE"]) { JSON.parse(`#{@haml}`) }
   end
 
 GithubCheckRunService.new(@report, @github_data, ReportAdapter).run

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -19,11 +19,11 @@ end
   repo: ENV["GITHUB_REPOSITORY_NAME"] || @event_json.dig("repository", "name"),
 }
 
-@haml = "haml-lint " + ENV["FILE_PATHS"]
-@haml += "-r json"
-@haml += " -c " + ENV["CONFIG_PATH"] if ENV["CONFIG_PATH"]
-@haml += " -e " + ENV["EXCLUDE_FILES"] if ENV["EXCLUDE_FILES"]
-@haml += " --fail-level " + ENV["FAIL_LEVEL"]
+@haml = "haml-lint " + ENV["INPUT_FILE_PATHS"]
+@haml += " -r json"
+@haml += " -c " + ENV["INPUT_CONFIG_PATH"] if ENV["INPUT_CONFIG_PATH"]
+@haml += " -e " + ENV["INPUT_EXCLUDE_PATHS"] if ENV["INPUT_EXCLUDE_PATHS"]
+@haml += " --fail-level " + ENV["INPUT_FAIL_LEVEL"]
 
 @report =
   if ENV["REPORT_PATH"]

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -21,8 +21,8 @@ end
 
 @haml = "haml-lint " + ENV["INPUT_FILE_PATHS"]
 @haml += " -r json"
-@haml += " -c " + ENV["INPUT_CONFIG_PATH"] if ENV["INPUT_CONFIG_PATH"]
-@haml += " -e " + ENV["INPUT_EXCLUDE_PATHS"] if ENV["INPUT_EXCLUDE_PATHS"]
+@haml += " -c " + ENV["INPUT_CONFIG_PATH"] if ENV["INPUT_CONFIG_PATH"] != ""
+@haml += " -e " + ENV["INPUT_EXCLUDE_PATHS"] if ENV["INPUT_EXCLUDE_PATHS"] != ""
 @haml += " --fail-level " + ENV["INPUT_FAIL_LEVEL"]
 
 @report =

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -30,7 +30,7 @@ end
     read_json(ENV["REPORT_PATH"])
   else
     Dir.chdir(ENV["GITHUB_WORKSPACE"]) {
-      JSON.parse(System(@haml))
+      JSON.parse(system(@haml))
     }
   end
 

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -19,17 +19,11 @@ end
   repo: ENV["GITHUB_REPOSITORY_NAME"] || @event_json.dig("repository", "name"),
 }
 
-@params = {
-  file_paths: ENV["FILE_PATHS"],
-  config_path: ENV["CONFIG_PATH"],
-  exclude_files: ENV["EXCLUDE_FILES"],
-  fail_level: ENV["FAIL_LEVEL"]
-}
-
-@haml = "haml-lint -r json"
-@haml += " -c " + @params.config_path if ENV["CONFIG_PATH"]
-@haml += " -e " + @params.exclude_files if ENV["EXCLUDE_FILES"]
-@haml += " --fail-level " + @params.fail_level
+@haml = "haml-lint " + ENV["FILE_PATHS"]
+@haml += "-r json"
+@haml += " -c " + ENV["CONFIG_PATH"] if ENV["CONFIG_PATH"]
+@haml += " -e " + ENV["EXCLUDE_FILES"] if ENV["EXCLUDE_FILES"]
+@haml += " --fail-level " + ENV["FAIL_LEVEL"]
 
 @report =
   if ENV["REPORT_PATH"]


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)
Enhancement

## Description

Please include a summary of the change and which issue is fixed.
- Need the ability to add other rubocop gems to install when haml-lint executes #4 
- Adds The ability to set the version of haml-lint
- Adds the ability to set args of
   - config
   - exclude
   - fail level
- Adds the ability to set file path to analyze

Fixes # (issue)

## Why should this be added

Explain value.
Gives users ability to be flexible to using haml lint

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Actions are passing
